### PR TITLE
Possible typos in test 5

### DIFF
--- a/testinternal.cpp
+++ b/testinternal.cpp
@@ -452,7 +452,7 @@ bool testinternal::testFour(QString &outString)
     for (auto i : qAsConst(org.genome)) if (!i) testFlag = false;
 
     QString flagString = testFlag ? "true" : "false";
-    out << "\n\nGiven the mapping the first genome should be all zeros, no matter what the stochastic genome, and the second all ones. TRevoSIm tested this and returned " << flagString << ".";
+    out << "\n\nGiven the mapping the first genome should be all zeros, no matter what the stochastic genome, and the second all ones. TREvoSim tested this and returned " << flagString << ".";
 
     if (testFlag) out << "\n\nStochastic mapping tests passed.\n";
     return testFlag;
@@ -491,10 +491,10 @@ bool testinternal::testFive(QString &outString)
     }
 
     double mean = static_cast<double>(cnt) / 10000;
-    QString flagString = testFlag ? "true" : "false";
-    out << "Ran 10000 mutations of a 128 bit organism. At a rate of " << simSettings.organismMutationRate << "mutation per hundred characters per iteration this resulted in a mean of ";
-    out << mean << " mutations. TREvoSim expects this to be between 1.25 and 1.31 and returned " << flagString << "\n";
     if (mean < 1.25 || mean > 1.31) testFlag = false;
+    QString flagString = testFlag ? "true" : "false";
+    out << "Ran 10000 iterations of a 128 bit organism. At a rate of " << simSettings.organismMutationRate << " mutation per hundred characters per iteration this resulted in a mean of ";
+    out << mean << " mutations. TREvoSim expects this to be between 1.25 and 1.31 and returned " << flagString << ".\n";
 
     simSettings.environmentNumber = 2;
     simSettings.playingfieldNumber = 2;


### PR DESCRIPTION
- The test of the value `mean` is performed after its result is reported – so the test will always report "TRUE".
- I think the text means to say "Ran 10000 iterations" rather than "10k mutations" (though the two are equivalent at the given rate).  I found the existing text confusing.
- (Also fixed a couple of trivial copyedits)