### PR TITLE
Speciation mode

### DIFF
--- a/.astylerc
+++ b/.astylerc
@@ -1,3 +1,6 @@
+# RJG - Palaeoware code style through astyle
+# RJG - to enable the beautifier in QT creator, go to Help > About Plugins > C++ > Beautifier, then Tools > Options > Beautifier
+
 --style=allman
 --indent=spaces=4
 --align-pointer=name

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,8 @@ set(CMAKE_AUTOUIC ON)
 set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTORCC ON)
 
+set(CMAKE_BUILD_PARALLEL_LEVEL 8)
+
 if(WIN32)
     #Included here to build the .dlls for GoogleTest under Windows
     set(BUILD_SHARED_LIBS ON)

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -22,7 +22,7 @@
 //Speciation mode
 #define SPECIES_MODE_ORIGIN 0
 #define SPECIES_MODE_LAST_SPECIATION 1
-#define SPECIES_MODE_ORIGIN_AND_LAST 2
+#define SPECIES_MODE_ALL 2
 #define SPECIES_MODE_MAYR 3
 
 //Forward declaration to avoid circular dependencies in printGenome declaration

--- a/organism.cpp
+++ b/organism.cpp
@@ -7,11 +7,11 @@ Organism::Organism(int genomeSize, bool stochastic)
     stochasticLayer = stochastic;
 
     // Initialise everything to false/-1 to make it obvious if it has not been changed.
-    parentGenome.append(QList <bool>());
+    parentGenomes.append(QList <bool>());
     for (int i = 0; i < genomeSize; i++)
     {
         genome.append(false);
-        parentGenome[0].append(false);
+        parentGenomes[0].append(false);
     }
 
     if (stochasticLayer)
@@ -28,22 +28,22 @@ Organism::Organism(int genomeSize, bool stochastic)
 
 void Organism::initialise(int genomeSize)
 {
-    // Initialise genome, assume this is first organism, and prog genome same as genome
+    // Initialise genome; this is the first organism; parent genome is initialised as identical to starting point (genome will evolve away from this)
     for (int i = 0; i < genomeSize; i++)
     {
         if (QRandomGenerator::global()->generate() > (QRandomGenerator::max() / 2))
         {
             genome[i] = true;
-            parentGenome[0][i] = true;
+            parentGenomes[0][i] = true;
         }
         else
         {
             genome[i] = false;
-            parentGenome[0][i] = false;
+            parentGenomes[0][i] = false;
         }
     }
 
-    //This is true for first organism. Which is pretty much only time I initialise one currently.
+    //This is true for first organism, which is the only time one is initialised - otherwise they are just copied.
     speciesID = 0;
     parentSpeciesID = 0;
 
@@ -64,7 +64,7 @@ void Organism::initialise(int genomeSize, const int *stochasticMap)
         else stochasticGenome[i] = false;
     this->mapFromStochastic(stochasticMap);
 
-    for (int i = 0; i < genomeSize; i++) parentGenome[0][i] = genome[i];
+    for (int i = 0; i < genomeSize; i++) parentGenomes[0][i] = genome[i];
 
     //This is true for first organism. Which is pretty much only time I initialise one currently.
     speciesID = 0;
@@ -84,7 +84,7 @@ void Organism::operator = (const Organism &O)
 {
     // Copy all attributes
     genome = O.genome;
-    parentGenome = O.parentGenome;
+    parentGenomes = O.parentGenomes;
     if (stochasticLayer) stochasticGenome = O.stochasticGenome;
     speciesID = O.speciesID;
     parentSpeciesID = O.parentSpeciesID;
@@ -98,7 +98,7 @@ void Organism::operator = (const Organism &O)
 bool Organism::operator == (const Organism &O)
 {
     if (genome != O.genome) return false;
-    if (parentGenome != O.parentGenome) return false;
+    if (parentGenomes != O.parentGenomes) return false;
     if (stochasticLayer && (stochasticGenome != O.stochasticGenome)) return false;
     if (speciesID != O.speciesID) return false;
     if (parentSpeciesID != O.parentSpeciesID) return false;

--- a/organism.cpp
+++ b/organism.cpp
@@ -7,10 +7,11 @@ Organism::Organism(int genomeSize, bool stochastic)
     stochasticLayer = stochastic;
 
     // Initialise everything to false/-1 to make it obvious if it has not been changed.
+    parentGenome.append(QList <bool>());
     for (int i = 0; i < genomeSize; i++)
     {
         genome.append(false);
-        parentGenome.append(false);
+        parentGenome[0].append(false);
     }
 
     if (stochasticLayer)
@@ -33,12 +34,12 @@ void Organism::initialise(int genomeSize)
         if (QRandomGenerator::global()->generate() > (QRandomGenerator::max() / 2))
         {
             genome[i] = true;
-            parentGenome[i] = true;
+            parentGenome[0][i] = true;
         }
         else
         {
             genome[i] = false;
-            parentGenome[i] = false;
+            parentGenome[0][i] = false;
         }
     }
 
@@ -63,7 +64,7 @@ void Organism::initialise(int genomeSize, const int *stochasticMap)
         else stochasticGenome[i] = false;
     this->mapFromStochastic(stochasticMap);
 
-    for (int i = 0; i < genomeSize; i++) parentGenome[i] = genome[i];
+    for (int i = 0; i < genomeSize; i++) parentGenome[0][i] = genome[i];
 
     //This is true for first organism. Which is pretty much only time I initialise one currently.
     speciesID = 0;

--- a/organism.h
+++ b/organism.h
@@ -10,15 +10,13 @@ public:
     //Explicit default copy constructor to avoid compile warnings
     Organism(const Organism &) = default;
 
-    //Genome of species and progenator
-    //Do as bools in order to make genome size easily scaleable - speed not much of an issue here
-    //resize from method if needed
+    //Genome of species and ancestors
+    //Do as vectors in order to make genome size easily scaleable - speed not much of an issue here
+    QList <bool> genome; //Organisms genome
+    QList <QList <bool> > parentGenomes;//Gnome of any parents, and also any other speciation from within this lineage
+    QList <bool> stochasticGenome;//Used for many to one mapping of a genome
 
-    QList <bool> genome;
-    QList <QList <bool> > parentGenome;
-    QList <bool> stochasticGenome;
-
-    // ID of species and progenator
+    // ID of species and parent
     int speciesID;
     int parentSpeciesID;
 

--- a/organism.h
+++ b/organism.h
@@ -15,7 +15,7 @@ public:
     //resize from method if needed
 
     QList <bool> genome;
-    QList <bool> parentGenome;
+    QList <QList <bool> > parentGenome;
     QList <bool> stochasticGenome;
 
     // ID of species and progenator

--- a/settings.cpp
+++ b/settings.cpp
@@ -122,7 +122,7 @@ Settings::Settings(QWidget *parent, simulationVariables *simSettings) :
     QStringList comboOptions;
     comboOptions.insert(SPECIES_MODE_ORIGIN, "Species origin");
     comboOptions.insert(SPECIES_MODE_LAST_SPECIATION, "Last speciation");
-    comboOptions.insert(SPECIES_MODE_ORIGIN_AND_LAST, "Origin and all speciations");
+    comboOptions.insert(SPECIES_MODE_ALL, "Origin and all speciations");
     comboOptions.insert(SPECIES_MODE_MAYR, "Mayr");
 
     ui->combo_speciation->addItems(comboOptions);
@@ -147,7 +147,6 @@ void Settings::on_buttonBox_accepted()
     settings->ecosystemEngineeringFrequency = ui->s_EE_frequency->value();
 
     settings->stripUninformative = ui->c_strip_uninformative->isChecked();
-    qDebug() << ui->c_sansomian->isChecked();
     settings->genomeOnExtinction = ui->c_sansomian->isChecked();
     settings->discardDeleterious = ui->c_beneficial_mut->isChecked();
     settings->environmentalPerturbation = ui->c_extinction->isChecked();

--- a/settings.cpp
+++ b/settings.cpp
@@ -181,6 +181,8 @@ void Settings::on_buttonBox_accepted()
     if (ui->r_once_EE->isChecked())settings->ecosystemEngineersArePersistent = false;
     else settings->ecosystemEngineersArePersistent = true;
 
+    settings->speciationMode = ui->combo_speciation->currentIndex();
+
     if (ui->c_stochastic->isChecked())
     {
         QDialog stochasticDialog(this);

--- a/settings.ui
+++ b/settings.ui
@@ -24,33 +24,32 @@
        <string>Organisms and simulation</string>
       </attribute>
       <layout class="QGridLayout" name="gridLayout">
-       <item row="0" column="0" colspan="3">
-        <widget class="QLabel" name="docs_label_01">
-         <property name="text">
-          <string>Textlabel</string>
+       <item row="6" column="2">
+        <widget class="QSpinBox" name="s_select_size">
+         <property name="minimum">
+          <number>1</number>
+         </property>
+         <property name="maximum">
+          <number>999</number>
          </property>
         </widget>
        </item>
-       <item row="25" column="0" colspan="3">
-        <widget class="QCheckBox" name="c_noSelection">
+       <item row="16" column="1" colspan="2">
+        <widget class="QRadioButton" name="r_taxon_number">
          <property name="text">
-          <string>No selection</string>
+          <string>Run to taxon number</string>
          </property>
         </widget>
        </item>
-       <item row="28" column="0">
-        <widget class="QCheckBox" name="c_strip_uninformative">
+       <item row="4" column="0">
+        <widget class="QLabel" name="label_3">
          <property name="text">
-          <string>Strip uninformative characters via subsampling</string>
+          <string>Number of characters</string>
          </property>
         </widget>
        </item>
-       <item row="7" column="0">
-        <widget class="QLabel" name="label_4">
-         <property name="text">
-          <string>Characters for fitness calculation</string>
-         </property>
-        </widget>
+       <item row="24" column="2">
+        <widget class="QSpinBox" name="s_fitness_target"/>
        </item>
        <item row="21" column="2">
         <widget class="QSpinBox" name="s_species_difference">
@@ -59,75 +58,6 @@
          </property>
          <property name="maximum">
           <number>999</number>
-         </property>
-        </widget>
-       </item>
-       <item row="17" column="2">
-        <widget class="QSpinBox" name="s_taxon_number">
-         <property name="minimum">
-          <number>1</number>
-         </property>
-         <property name="maximum">
-          <number>9999</number>
-         </property>
-        </widget>
-       </item>
-       <item row="4" column="1">
-        <spacer name="horizontalSpacer_4">
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>40</width>
-           <height>20</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-       <item row="12" column="0">
-        <widget class="QCheckBox" name="c_stochastic">
-         <property name="text">
-          <string>Stochastic layer</string>
-         </property>
-        </widget>
-       </item>
-       <item row="1" column="0" colspan="3">
-        <widget class="QPushButton" name="docs_pushButton_01">
-         <property name="text">
-          <string>See documentation</string>
-         </property>
-        </widget>
-       </item>
-       <item row="2" column="0" colspan="3">
-        <widget class="QLabel" name="label_12">
-         <property name="font">
-          <font>
-           <pointsize>11</pointsize>
-           <bold>true</bold>
-           <underline>true</underline>
-          </font>
-         </property>
-         <property name="text">
-          <string>Organisms</string>
-         </property>
-        </widget>
-       </item>
-       <item row="26" column="0" colspan="3">
-        <widget class="QCheckBox" name="c_sansomian">
-         <property name="text">
-          <string>Record genomes on extinction</string>
-         </property>
-        </widget>
-       </item>
-       <item row="21" column="0">
-        <widget class="QLabel" name="label_6">
-         <property name="text">
-          <string>Species difference</string>
-         </property>
-        </widget>
-       </item>
-       <item row="16" column="0">
-        <widget class="QRadioButton" name="r_iterations">
-         <property name="text">
-          <string>Run for iteration number</string>
          </property>
         </widget>
        </item>
@@ -145,92 +75,6 @@
          </property>
         </widget>
        </item>
-       <item row="16" column="1" colspan="2">
-        <widget class="QRadioButton" name="r_taxon_number">
-         <property name="text">
-          <string>Run to taxon number</string>
-         </property>
-        </widget>
-       </item>
-       <item row="18" column="2">
-        <widget class="QSpinBox" name="s_run_for">
-         <property name="minimum">
-          <number>1</number>
-         </property>
-         <property name="maximum">
-          <number>1000000</number>
-         </property>
-        </widget>
-       </item>
-       <item row="29" column="0">
-        <widget class="QCheckBox" name="c_randomSeed">
-         <property name="text">
-          <string>Random starting individual</string>
-         </property>
-        </widget>
-       </item>
-       <item row="23" column="2">
-        <widget class="QSpinBox" name="s_unresolvable_c">
-         <property name="minimum">
-          <number>2</number>
-         </property>
-        </widget>
-       </item>
-       <item row="23" column="0">
-        <widget class="QLabel" name="label_11">
-         <property name="text">
-          <string>Unresolvable cutoff</string>
-         </property>
-        </widget>
-       </item>
-       <item row="4" column="2">
-        <widget class="QSpinBox" name="s_genome_size">
-         <property name="minimum">
-          <number>10</number>
-         </property>
-         <property name="maximum">
-          <number>10000</number>
-         </property>
-        </widget>
-       </item>
-       <item row="11" column="0">
-        <widget class="QLabel" name="label_8">
-         <property name="text">
-          <string>Rate of organism mutation</string>
-         </property>
-        </widget>
-       </item>
-       <item row="27" column="0" colspan="3">
-        <widget class="QCheckBox" name="c_beneficial_mut">
-         <property name="text">
-          <string>Discard deleterious mutations</string>
-         </property>
-        </widget>
-       </item>
-       <item row="4" column="0">
-        <widget class="QLabel" name="label_3">
-         <property name="text">
-          <string>Number of characters</string>
-         </property>
-        </widget>
-       </item>
-       <item row="13" column="0">
-        <widget class="QLabel" name="label_25">
-         <property name="text">
-          <string>Depth of layer</string>
-         </property>
-        </widget>
-       </item>
-       <item row="24" column="0">
-        <widget class="QLabel" name="label_5">
-         <property name="text">
-          <string>Fitness target</string>
-         </property>
-        </widget>
-       </item>
-       <item row="24" column="2">
-        <widget class="QSpinBox" name="s_fitness_target"/>
-       </item>
        <item row="13" column="2">
         <widget class="QSpinBox" name="s_stochasticDepth">
          <property name="minimum">
@@ -241,17 +85,30 @@
          </property>
         </widget>
        </item>
-       <item row="6" column="0" colspan="2">
-        <widget class="QLabel" name="label">
+       <item row="27" column="0" colspan="3">
+        <widget class="QCheckBox" name="c_beneficial_mut">
          <property name="text">
-          <string>Characters for species identification</string>
+          <string>Discard deleterious mutations</string>
          </property>
         </widget>
        </item>
-       <item row="17" column="0">
-        <widget class="QLabel" name="label_2">
+       <item row="4" column="1">
+        <spacer name="horizontalSpacer_4">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>40</width>
+           <height>20</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item row="21" column="0">
+        <widget class="QLabel" name="label_6">
          <property name="text">
-          <string>Run to taxon number:</string>
+          <string>Species difference</string>
          </property>
         </widget>
        </item>
@@ -265,17 +122,34 @@
          </property>
         </widget>
        </item>
-       <item row="20" column="0">
-        <widget class="QLabel" name="label_26">
-         <property name="font">
-          <font>
-           <pointsize>11</pointsize>
-           <bold>true</bold>
-           <underline>true</underline>
-          </font>
-         </property>
+       <item row="1" column="0" colspan="3">
+        <widget class="QPushButton" name="docs_pushButton_01">
          <property name="text">
-          <string>Simulation (Organisms)</string>
+          <string>See documentation</string>
+         </property>
+        </widget>
+       </item>
+       <item row="13" column="0">
+        <widget class="QLabel" name="label_25">
+         <property name="text">
+          <string>Depth of layer</string>
+         </property>
+        </widget>
+       </item>
+       <item row="4" column="2">
+        <widget class="QSpinBox" name="s_genome_size">
+         <property name="minimum">
+          <number>10</number>
+         </property>
+         <property name="maximum">
+          <number>10000</number>
+         </property>
+        </widget>
+       </item>
+       <item row="17" column="0">
+        <widget class="QLabel" name="label_2">
+         <property name="text">
+          <string>Run to taxon number:</string>
          </property>
         </widget>
        </item>
@@ -292,6 +166,20 @@
          </property>
         </widget>
        </item>
+       <item row="22" column="0">
+        <widget class="QLabel" name="label_9">
+         <property name="text">
+          <string>Speciation mode</string>
+         </property>
+        </widget>
+       </item>
+       <item row="11" column="0">
+        <widget class="QLabel" name="label_8">
+         <property name="text">
+          <string>Rate of organism mutation</string>
+         </property>
+        </widget>
+       </item>
        <item row="18" column="0">
         <widget class="QLabel" name="label_27">
          <property name="text">
@@ -299,8 +187,111 @@
          </property>
         </widget>
        </item>
+       <item row="0" column="0" colspan="3">
+        <widget class="QLabel" name="docs_label_01">
+         <property name="text">
+          <string>Textlabel</string>
+         </property>
+        </widget>
+       </item>
+       <item row="12" column="0">
+        <widget class="QCheckBox" name="c_stochastic">
+         <property name="text">
+          <string>Stochastic layer</string>
+         </property>
+        </widget>
+       </item>
+       <item row="26" column="0" colspan="3">
+        <widget class="QCheckBox" name="c_sansomian">
+         <property name="text">
+          <string>Record genomes on extinction</string>
+         </property>
+        </widget>
+       </item>
+       <item row="16" column="0">
+        <widget class="QRadioButton" name="r_iterations">
+         <property name="text">
+          <string>Run for iteration number</string>
+         </property>
+        </widget>
+       </item>
+       <item row="20" column="0" colspan="2">
+        <widget class="QLabel" name="label_26">
+         <property name="font">
+          <font>
+           <pointsize>11</pointsize>
+           <bold>true</bold>
+           <underline>true</underline>
+          </font>
+         </property>
+         <property name="text">
+          <string>Simulation (Organisms)</string>
+         </property>
+        </widget>
+       </item>
+       <item row="18" column="2">
+        <widget class="QSpinBox" name="s_run_for">
+         <property name="minimum">
+          <number>1</number>
+         </property>
+         <property name="maximum">
+          <number>1000000</number>
+         </property>
+        </widget>
+       </item>
+       <item row="23" column="2">
+        <widget class="QSpinBox" name="s_unresolvable_c">
+         <property name="minimum">
+          <number>2</number>
+         </property>
+        </widget>
+       </item>
+       <item row="22" column="1" colspan="2">
+        <widget class="QComboBox" name="combo_speciation"/>
+       </item>
+       <item row="2" column="0" colspan="3">
+        <widget class="QLabel" name="label_12">
+         <property name="font">
+          <font>
+           <pointsize>11</pointsize>
+           <bold>true</bold>
+           <underline>true</underline>
+          </font>
+         </property>
+         <property name="text">
+          <string>Organisms</string>
+         </property>
+        </widget>
+       </item>
+       <item row="17" column="2">
+        <widget class="QSpinBox" name="s_taxon_number">
+         <property name="minimum">
+          <number>1</number>
+         </property>
+         <property name="maximum">
+          <number>9999</number>
+         </property>
+        </widget>
+       </item>
+       <item row="7" column="0">
+        <widget class="QLabel" name="label_4">
+         <property name="text">
+          <string>Characters for fitness calculation</string>
+         </property>
+        </widget>
+       </item>
+       <item row="6" column="0" colspan="2">
+        <widget class="QLabel" name="label">
+         <property name="text">
+          <string>Characters for species identification</string>
+         </property>
+        </widget>
+       </item>
        <item row="21" column="1">
         <spacer name="horizontalSpacer_2">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
          <property name="sizeHint" stdset="0">
           <size>
            <width>40</width>
@@ -309,25 +300,40 @@
          </property>
         </spacer>
        </item>
-       <item row="6" column="2">
-        <widget class="QSpinBox" name="s_select_size">
-         <property name="minimum">
-          <number>1</number>
-         </property>
-         <property name="maximum">
-          <number>999</number>
-         </property>
-        </widget>
-       </item>
-       <item row="22" column="0">
-        <widget class="QLabel" name="label_9">
+       <item row="25" column="0" colspan="3">
+        <widget class="QCheckBox" name="c_noSelection">
          <property name="text">
-          <string>Speciation mode</string>
+          <string>No selection</string>
          </property>
         </widget>
        </item>
-       <item row="22" column="2">
-        <widget class="QComboBox" name="combo_speciation"/>
+       <item row="28" column="0" colspan="3">
+        <widget class="QCheckBox" name="c_strip_uninformative">
+         <property name="text">
+          <string>Strip uninformative characters via subsampling</string>
+         </property>
+        </widget>
+       </item>
+       <item row="29" column="0" colspan="3">
+        <widget class="QCheckBox" name="c_randomSeed">
+         <property name="text">
+          <string>Random starting individual</string>
+         </property>
+        </widget>
+       </item>
+       <item row="24" column="0" colspan="2">
+        <widget class="QLabel" name="label_5">
+         <property name="text">
+          <string>Fitness target</string>
+         </property>
+        </widget>
+       </item>
+       <item row="23" column="0" colspan="2">
+        <widget class="QLabel" name="label_11">
+         <property name="text">
+          <string>Unresolvable cutoff</string>
+         </property>
+        </widget>
        </item>
       </layout>
      </widget>
@@ -421,6 +427,9 @@
        </item>
        <item row="12" column="1">
         <spacer name="horizontalSpacer_3">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
          <property name="sizeHint" stdset="0">
           <size>
            <width>40</width>
@@ -438,6 +447,9 @@
        </item>
        <item row="19" column="0">
         <spacer name="verticalSpacer">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
          <property name="sizeHint" stdset="0">
           <size>
            <width>20</width>
@@ -493,6 +505,9 @@
        </item>
        <item row="4" column="1">
         <spacer name="horizontalSpacer">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
          <property name="sizeHint" stdset="0">
           <size>
            <width>40</width>

--- a/simulation.cpp
+++ b/simulation.cpp
@@ -1744,37 +1744,52 @@ int simulation::fitness(const Organism *org, const QVector<QVector<QVector<bool>
     return fitness;
 }
 
-int simulation::genomeDifference(const Organism *organismOne, const Organism *organismTwo)
+//Selectsize defaults to -1
+int simulation::genomeDifference(const Organism *organismOne, const Organism *organismTwo, const int selectSize)
 {
     int diff = 0;
-    for (int j = 0; j < organismOne->genome.length(); j++)
-        if (organismOne->genome[j] != organismTwo->genome[j])diff++;
+    if (selectSize == -1)
+    {
+        for (int j = 0; j < organismOne->genome.length(); j++)
+            if (organismOne->genome[j] != organismTwo->genome[j])diff++;
+    }
+    else
+    {
+        for (int j = 0; j < selectSize; j++)
+            if (organismOne->genome[j] != organismTwo->genome[j])diff++;
+    }
     return diff;
 }
 
 bool simulation::checkForSpeciation(const Organism *organismOne, int runSelectSize, int runSpeciesDifference, int speciationMode)
 {
     int difference = 0;
-    //Loop to select size to allow decoupling of species definition from genome size.
 
-//Speciation mode
-#define SPECIES_MODE_ORIGIN 0
-#define SPECIES_MODE_LAST_SPECIATION 1
-#define SPECIES_MODE_ORIGIN_AND_LAST 2
-#define SPECIES_MODE_MAYR 3
-    int count = organismOne->parentGenome.count();
+    //Speciation mode
+    //SPECIES_MODE_ORIGIN 0
+    //SPECIES_MODE_LAST_SPECIATION 1
+    //SPECIES_MODE_ORIGIN_AND_LAST 2
+    //SPECIES_MODE_MAYR 3
+
+    int gnomeCount = organismOne->parentGenome.count();
     if (simSettings->speciationMode == SPECIES_MODE_ORIGIN)
+    {
+        //Loop to select size to allow decoupling of species definition from genome size: hence also can't just use the count difference function above
         for (int j = 0; j < runSelectSize; j++)
             if (organismOne->genome[j] != organismOne->parentGenome[0][j])
                 difference++;
-            else if (simSettings->speciationMode == SPECIES_MODE_LAST_SPECIATION)
+    }
+    else if (simSettings->speciationMode == SPECIES_MODE_LAST_SPECIATION)
+    {
 
-                //Just use function above?
+    }
 
-                if (difference >= runSpeciesDifference)
-                    return true;
-                else
-                    return false;
+    //Just use function above?
+
+    if (difference >= runSpeciesDifference)
+        return true;
+    else
+        return false;
 }
 
 int simulation::returninformativeCharacters()

--- a/simulation.cpp
+++ b/simulation.cpp
@@ -1754,14 +1754,27 @@ int simulation::genomeDifference(const Organism *organismOne, const Organism *or
 
 bool simulation::checkForSpeciation(const Organism *organismOne, int runSelectSize, int runSpeciesDifference, int speciationMode)
 {
-    int diff = 0;
+    int difference = 0;
     //Loop to select size to allow decoupling of species definition from genome size.
-    for (int j = 0; j < runSelectSize; j++)
-        if (organismOne->genome[j] != organismOne->parentGenome[j])diff++;
 
+//Speciation mode
+#define SPECIES_MODE_ORIGIN 0
+#define SPECIES_MODE_LAST_SPECIATION 1
+#define SPECIES_MODE_ORIGIN_AND_LAST 2
+#define SPECIES_MODE_MAYR 3
+    int count = organismOne->parentGenome.count();
+    if (simSettings->speciationMode == SPECIES_MODE_ORIGIN)
+        for (int j = 0; j < runSelectSize; j++)
+            if (organismOne->genome[j] != organismOne->parentGenome[0][j])
+                difference++;
+            else if (simSettings->speciationMode == SPECIES_MODE_LAST_SPECIATION)
 
-    if (diff >= runSpeciesDifference) return true;
-    else return false;
+                //Just use function above?
+
+                if (difference >= runSpeciesDifference)
+                    return true;
+                else
+                    return false;
 }
 
 int simulation::returninformativeCharacters()

--- a/simulation.cpp
+++ b/simulation.cpp
@@ -1782,11 +1782,21 @@ bool simulation::checkForSpeciation(const Organism *organismOne, int runSelectSi
     else if (simSettings->speciationMode == SPECIES_MODE_LAST_SPECIATION)
     {
         for (int j = 0; j < runSelectSize; j++)
-            if (organismOne->genome[j] != organismOne->parentGenome[genomeCount-1][j])
+            if (organismOne->genome[j] != organismOne->parentGenome[genomeCount - 1][j])
                 difference++;
     }
-
-    //Just use function above?
+    else if (simSettings->speciationMode == SPECIES_MODE_ORIGIN_AND_LAST)
+    {
+        difference = runSelectSize;
+        for (int i = 0; i < genomeCount; i++)
+        {
+            int tempDiff = 0;
+            for (int j = 0; j < runSelectSize; j++)
+                if (organismOne->genome[j] != organismOne->parentGenome[genomeCount - 1][j])
+                    tempDiff++;
+            if (tempDiff < difference) difference = tempDiff;
+        }
+    }
 
     if (difference >= runSpeciesDifference)
         return true;

--- a/simulation.cpp
+++ b/simulation.cpp
@@ -1730,32 +1730,32 @@ bool simulation::checkForSpeciation(const Organism *organismOne, int runSelectSi
     //SPECIES_MODE_MAYR 3 - not currently implemented
 
     int genomeCount = organismOne->parentGenomes.count();
-    if (simSettings->speciationMode == SPECIES_MODE_ORIGIN)
+    if (speciationMode == SPECIES_MODE_ORIGIN)
     {
         //Loop to select size to allow decoupling of species definition from genome size: also can't just use the count difference function above as this operates on organisms, not their genomes.
         for (int j = 0; j < runSelectSize; j++)
             if (organismOne->genome[j] != organismOne->parentGenomes[0][j])
                 difference++;
     }
-    else if (simSettings->speciationMode == SPECIES_MODE_LAST_SPECIATION)
+    else if (speciationMode == SPECIES_MODE_LAST_SPECIATION)
     {
         for (int j = 0; j < runSelectSize; j++)
             if (organismOne->genome[j] != organismOne->parentGenomes[genomeCount - 1][j])
                 difference++;
     }
-    else if (simSettings->speciationMode == SPECIES_MODE_ALL)
+    else if (speciationMode == SPECIES_MODE_ALL)
     {
-        difference = runSelectSize;
+        //We need to record the maximum level of difference, as the biggest is going to be closest to species difference
+        difference = 0;
         for (int i = 0; i < genomeCount; i++)
         {
             int tempDiff = 0;
             for (int j = 0; j < runSelectSize; j++)
-                if (organismOne->genome[j] != organismOne->parentGenomes[genomeCount - 1][j])
+                if (organismOne->genome[j] != organismOne->parentGenomes[i][j])
                     tempDiff++;
-            if (tempDiff < difference) difference = tempDiff;
+            if (tempDiff > difference) difference = tempDiff;
         }
     }
-
 
     if (difference >= runSpeciesDifference)
         return true;

--- a/simulation.cpp
+++ b/simulation.cpp
@@ -1798,6 +1798,8 @@ bool simulation::checkForSpeciation(const Organism *organismOne, int runSelectSi
         }
     }
 
+    qDebug() << difference;
+
     if (difference >= runSpeciesDifference)
         return true;
     else

--- a/simulation.cpp
+++ b/simulation.cpp
@@ -1771,17 +1771,19 @@ bool simulation::checkForSpeciation(const Organism *organismOne, int runSelectSi
     //SPECIES_MODE_ORIGIN_AND_LAST 2
     //SPECIES_MODE_MAYR 3
 
-    int gnomeCount = organismOne->parentGenome.count();
+    int genomeCount = organismOne->parentGenome.count();
     if (simSettings->speciationMode == SPECIES_MODE_ORIGIN)
     {
-        //Loop to select size to allow decoupling of species definition from genome size: hence also can't just use the count difference function above
+        //Loop to select size to allow decoupling of species definition from genome size: also can't just use the count difference function above as this operates on organisms, not their genomes.
         for (int j = 0; j < runSelectSize; j++)
             if (organismOne->genome[j] != organismOne->parentGenome[0][j])
                 difference++;
     }
     else if (simSettings->speciationMode == SPECIES_MODE_LAST_SPECIATION)
     {
-
+        for (int j = 0; j < runSelectSize; j++)
+            if (organismOne->genome[j] != organismOne->parentGenome[genomeCount-1][j])
+                difference++;
     }
 
     //Just use function above?

--- a/simulation.h
+++ b/simulation.h
@@ -94,8 +94,8 @@ private:
     void applyPerturbation();
     void applyPlayingfieldMixing(QVector<Organism *> &speciesList);
     void applyEcosystemEngineering(QVector<Organism *> &speciesList, bool writeEcosystemEngineers);
-    void testForUninformative(QVector <Organism *> &speciesList, QList <int> &uninformativeCoding, QList <int> &uninformativeNonCoding);
-    bool testForCharacterNumber(QList <int> &uninformativeCoding, QList <int> &uninformativeNonCoding);
+    void checkForUninformative(QVector <Organism *> &speciesList, QList <int> &uninformativeCoding, QList <int> &uninformativeNonCoding);
+    bool checkForCharacterNumber(QList <int> &uninformativeCoding, QList <int> &uninformativeNonCoding);
     bool stripUninformativeCharacters(QVector<Organism *> &speciesList, const QList <int> &uninformativeCoding, const QList <int> &uninformativeNonCoding);
     bool checkForUnresolvableTaxa(QVector<Organism *> &speciesList, QString &unresolvableTaxonGroups, int &unresolvableCount);
     bool writeFile(const QString logFileNameBase, const QString logFileExtension, const QString logFileString, const QHash<QString, QString> &outValues, const QVector<Organism *> &speciesList);
@@ -110,7 +110,7 @@ private:
     int genomeDifference(const Organism *organismOne, const Organism *organismTwo);
     QHash<QString, QVector<int> > checkForExtinct(const QVector <Organism *> &speciesList);
     void speciesExtinction(Organism *speciesListOrganism, const Organism *playingFieldOrganism, int extinctIteration, bool samsonian, bool stochastic, bool test = false);
-    int checkForSpeciation(const Organism *organismOne, int runSelectSize);
+    bool checkForSpeciation(const Organism *organismOne, int runSelectSize, int runSpeciesDifference, int speciationMode);
 };
 
 #endif // SIMULATION_H

--- a/simulation.h
+++ b/simulation.h
@@ -107,7 +107,7 @@ private:
 
     //Simulation calculations
     int fitness(const Organism *org, const QVector<QVector<QVector<bool> > > &masks, int runFitnessSize, int runFitnessTarget, int runMaskNumber, int environment = -1);
-    int genomeDifference(const Organism *organismOne, const Organism *organismTwo);
+    int genomeDifference(const Organism *organismOne, const Organism *organismTwo, const int selectSize = -1);
     QHash<QString, QVector<int> > checkForExtinct(const QVector <Organism *> &speciesList);
     void speciesExtinction(Organism *speciesListOrganism, const Organism *playingFieldOrganism, int extinctIteration, bool samsonian, bool stochastic, bool test = false);
     bool checkForSpeciation(const Organism *organismOne, int runSelectSize, int runSpeciesDifference, int speciationMode);

--- a/testinternal.cpp
+++ b/testinternal.cpp
@@ -733,71 +733,73 @@ bool testinternal::testSeven(QString &outString)
     QTextStream out(&outString);
 
     out << "Testing the creation of a new species - new species created at iteration 66 with a genome of all 1's.\n\n";
-    /*
-        simulationVariables simSettings;
-        simSettings.genomeSize = 50;
-        simSettings.fitnessSize = 50;
-        simSettings.speciesSelectSize = 50;
-        simSettings.test = 7;
 
-        simulation x(0, &simSettings, &error, theMainWindow);
+    simulationVariables simSettings;
+    simSettings.genomeSize = 50;
+    simSettings.fitnessSize = 50;
+    simSettings.speciesSelectSize = 50;
+    simSettings.test = 7;
 
-        if (error)
-        {
-            out << "Error initialising test simulation";
-            return false;
-        }
-        //This should update the counters on new species
-        x.iterations = 66;
-        x.speciesCount = 14;
+    simulation x(0, &simSettings, &error, theMainWindow);
 
-        //This will have initialised values - i.e. zero for everything except the genome, which will be 50% 1's
-        Organism newSpecies(50, false);
-        newSpecies.initialise(50);
-        newSpecies.speciesID = 10;
-        for (auto &i : newSpecies.genome) i = true;
+    if (error)
+    {
+        out << "Error initialising test simulation";
+        return false;
+    }
+    //This should update the counters on new species
+    x.iterations = 66;
+    x.speciesCount = 14;
 
-        Organism parentSpecies(50, false);
-        for (auto &i : parentSpecies.genome)i = true;
-        for (auto &i : parentSpecies.parentGenome)i = true;
-        parentSpecies.speciesID = 10;
-        parentSpecies.parentSpeciesID = 9;
-        parentSpecies.born = 15;
-        parentSpecies.extinct = 20;
-        parentSpecies.cladogenesis = 25;
-        parentSpecies.fitness = 5;
-        x.playingFields[0]->playingField[8]->speciesID = 10;
+    //This will have initialised values - i.e. zero for everything except the genome, which will be 50% 1's
+    Organism newSpecies(50, false);
+    newSpecies.initialise(50);
+    newSpecies.speciesID = 10;
+    for (auto &i : newSpecies.genome) i = true;
 
-        x.newSpecies(newSpecies, parentSpecies, x.playingFields[0]);
+    Organism parentSpecies(50, false);
+    for (auto &i : parentSpecies.genome)i = true;
+    for (auto &i : parentSpecies.parentGenomes[0])i = true;
+    parentSpecies.speciesID = 10;
+    parentSpecies.parentSpeciesID = 9;
+    parentSpecies.born = 15;
+    parentSpecies.extinct = 20;
+    parentSpecies.cladogenesis = 25;
+    parentSpecies.fitness = 5;
+    x.playingFields[0]->playingField[8]->speciesID = 10;
 
-        //Ok, so first, newspecies should be born iteration 66
-        if (newSpecies.born != 66)testFlag = false;
-        out << "New species born at iteration " << newSpecies.born << " (should be 66).\n";
-        if (x.speciesCount != 15)testFlag = false;
-        out << "Species number " << x.speciesCount << " (should be 15).\n";
-        if (newSpecies.speciesID != 15)testFlag = false;
-        out << "New species is " << newSpecies.speciesID << " (should be 15).\n";
-        if (newSpecies.cladogenesis != 66)testFlag = false;
-        out << "New species cladogenesis at iteration " << newSpecies.cladogenesis << " (should be 66).\n";
-        if (parentSpecies.cladogenesis != 66)testFlag = false;
-        out << "Parent cladogenesis at iteration " << parentSpecies.cladogenesis << " (should be 66).\n";
-        if (newSpecies.parentSpeciesID != 10)testFlag = false;
-        out << "New species parent species ID " << newSpecies.parentSpeciesID << " (should be 10).\n";
-        for (auto i : std::as_const(newSpecies.parentGenome)) if (i != 1)testFlag = false;
-        out << "New species parent genome: ";
-        for (auto i : std::as_const(newSpecies.parentGenome)) i ? out << "1" : out << "0";
-        out << " (should be all 1s).\n";
-        for (auto i : std::as_const(newSpecies.genome)) if (i != 1)testFlag = false;
-        out << "New species genome: ";
-        for (auto i : std::as_const(newSpecies.genome)) i ? out << "1" : out << "0";
-        out << " (should be all 1s).\n";
-        for (auto i : std::as_const(x.playingFields[0]->playingField[8]->parentGenome)) if (i != 1)testFlag = false;
-        out << "Species 10 parent genome in playing field is now: ";
-        for (auto i :  std::as_const(x.playingFields[0]->playingField[8]->parentGenome)) i ? out << "1" : out << "0";
-        out << " (should be all 1s).\n";
+    x.newSpecies(newSpecies, parentSpecies, x.playingFields[0]);
 
-        if (testFlag) out << "\nNew species tests passed.\n";
-    */
+    //Ok, so first, newspecies should be born iteration 66
+    if (newSpecies.born != 66)testFlag = false;
+    out << "New species born at iteration " << newSpecies.born << " (should be 66).\n";
+    if (x.speciesCount != 15)testFlag = false;
+    out << "Species number " << x.speciesCount << " (should be 15).\n";
+    if (newSpecies.speciesID != 15)testFlag = false;
+    out << "New species is " << newSpecies.speciesID << " (should be 15).\n";
+    if (newSpecies.cladogenesis != 66)testFlag = false;
+    out << "New species cladogenesis at iteration " << newSpecies.cladogenesis << " (should be 66).\n";
+    if (parentSpecies.cladogenesis != 66)testFlag = false;
+    out << "Parent cladogenesis at iteration " << parentSpecies.cladogenesis << " (should be 66).\n";
+    if (newSpecies.parentSpeciesID != 10)testFlag = false;
+    out << "New species parent species ID " << newSpecies.parentSpeciesID << " (should be 10).\n";
+    for (auto i : std::as_const(newSpecies.parentGenomes[0])) if (i != 1)testFlag = false;
+    out << "New species parent genome: ";
+    for (auto i : std::as_const(newSpecies.parentGenomes[0])) i ? out << "1" : out << "0";
+    out << " (should be all 1s).\n";
+    for (auto i : std::as_const(newSpecies.genome)) if (i != 1)testFlag = false;
+    out << "New species genome: ";
+    for (auto i : std::as_const(newSpecies.genome)) i ? out << "1" : out << "0";
+    out << " (should be all 1s).\n";
+    for (auto i : std::as_const(x.playingFields[0]->playingField[8]->parentGenomes[0])) if (i != 1)testFlag = false;
+    out << "Species 10 parent genome in playing field is now: ";
+    for (auto i :  std::as_const(x.playingFields[0]->playingField[8]->parentGenomes[0])) i ? out << "1" : out << "0";
+    out << " (should be all 1s).\n";
+    out << "Now look at appended genome.";
+    for (auto i :  std::as_const(x.playingFields[0]->playingField[8]->parentGenomes[1])) i ? out << "1" : out << "0";
+
+    if (testFlag) out << "\nNew species tests passed.\n";
+
     return testFlag;
 }
 
@@ -1742,7 +1744,7 @@ bool testinternal::testFourteen(QString &outString)
         out << "Fail at all species modes test F3\n";
     }
 
-    //Test with middle five away, reset original
+    //Test with middle as new species, reset original
     for (auto &p : org.parentGenomes[0]) p = false;
     for (int i = 0; i < 5; i++)
     {
@@ -1801,7 +1803,7 @@ bool testinternal::testFourteen(QString &outString)
         out << "Fail at all species modes test H3\n";
     }
 
-    //Test with last and middle five
+    //Test with last and middle
     for (int i = 0; i < 5; i++)
     {
         org.parentGenomes[1][i] = true;

--- a/testinternal.cpp
+++ b/testinternal.cpp
@@ -1591,7 +1591,7 @@ bool testinternal::testFourteen(QString &outString)
         if (!newSpecies)
         {
             testFlag = false;
-            out << "Fail at all species modes test " << i << "\n";
+            out << "Fail at all species modes test A" << i << "\n";
         }
     }
 
@@ -1605,7 +1605,7 @@ bool testinternal::testFourteen(QString &outString)
         if (newSpecies)
         {
             testFlag = false;
-            out << "Fail at all species modes test " << i << "\n";
+            out << "Fail at all species modes test B" << i << "\n";
         }
     }
     if (testFlag) out << "\n All species mode tests with single ancestor passed \n\n";
@@ -1617,57 +1617,71 @@ bool testinternal::testFourteen(QString &outString)
     //SPECIES_MODE_MAYR 3 - not currently implemented
     //checkForSpeciation(const Organism *organismOne, int runSelectSize, int runSpeciesDifference, int speciationMode)
 
-
+    //Next we need to do tests when we have more than one parental genome
     org.parentGenomes.append(QList <bool>());
     for (auto &p : org.parentGenomes[1]) p = false;
 
-    newSpecies = x.checkForSpeciation(&org, 50, 5, SPECIES_MODE_ORIGIN);
-    if (!newSpecies)
+    //At the moment, parent genome has four trues - everything should still be below species differemce no new species
+    for (int i = 0; i < 3; i++)
     {
-        testFlag = false;
-        out << "Fail at all species modes test 1\n";
-    }
-
-    newSpecies = x.checkForSpeciation(&org, 50, 5, SPECIES_MODE_LAST_SPECIATION);
-    if (!newSpecies)
-    {
-        testFlag = false;
-        out << "Fail at all species modes test 2\n";
-    }
-
-    newSpecies = x.checkForSpeciation(&org, 50, 5, SPECIES_MODE_ALL);
-    if (!newSpecies)
-    {
-        testFlag = false;
-        out << "Fail at all species modes test 3\n";
-    }
-
-    //Turn one bit false to take us below species difference
-    org.parentGenomes[0][4] = false;
-
-    newSpecies = x.checkForSpeciation(&org, 50, 5, SPECIES_MODE_ORIGIN);
-    if (newSpecies)
-    {
-        testFlag = false;
-        out << "Fail at all species modes test 4\n";
-    }
-
-    newSpecies = x.checkForSpeciation(&org, 50, 5, SPECIES_MODE_LAST_SPECIATION);
-    if (newSpecies)
-    {
-        testFlag = false;
-        out << "Fail at all species modes test 5\n";
-    }
-
-    newSpecies = x.checkForSpeciation(&org, 50, 5, SPECIES_MODE_ALL);
-    if (newSpecies)
-    {
-        testFlag = false;
-        out << "Fail at all species modes test 6\n";
+        newSpecies = x.checkForSpeciation(&org, 50, 5, i);
+        if (newSpecies)
+        {
+            testFlag = false;
+            out << "Fail at all species modes test C" << i << "\n";
+        }
     }
     if (testFlag) out << "\n All species mode tests with single ancestor passed \n\n";
 
 
+    /*
+        newSpecies = x.checkForSpeciation(&org, 50, 5, SPECIES_MODE_ORIGIN);
+        if (!newSpecies)
+        {
+            testFlag = false;
+            out << "Fail at all species modes test 1\n";
+        }
+
+        newSpecies = x.checkForSpeciation(&org, 50, 5, SPECIES_MODE_LAST_SPECIATION);
+        if (!newSpecies)
+        {
+            testFlag = false;
+            out << "Fail at all species modes test 2\n";
+        }
+
+        newSpecies = x.checkForSpeciation(&org, 50, 5, SPECIES_MODE_ALL);
+        if (!newSpecies)
+        {
+            testFlag = false;
+            out << "Fail at all species modes test 3\n";
+        }
+
+        //Turn one bit false to take us below species difference
+        org.parentGenomes[0][4] = false;
+
+        newSpecies = x.checkForSpeciation(&org, 50, 5, SPECIES_MODE_ORIGIN);
+        if (newSpecies)
+        {
+            testFlag = false;
+            out << "Fail at all species modes test 4\n";
+        }
+
+        newSpecies = x.checkForSpeciation(&org, 50, 5, SPECIES_MODE_LAST_SPECIATION);
+        if (newSpecies)
+        {
+            testFlag = false;
+            out << "Fail at all species modes test 5\n";
+        }
+
+        newSpecies = x.checkForSpeciation(&org, 50, 5, SPECIES_MODE_ALL);
+        if (newSpecies)
+        {
+            testFlag = false;
+            out << "Fail at all species modes test 6\n";
+        }
+        if (testFlag) out << "\n All species mode tests with single ancestor passed \n\n";
+
+    */
     return testFlag;
 }
 

--- a/testinternal.cpp
+++ b/testinternal.cpp
@@ -1134,7 +1134,7 @@ bool testinternal::testTen(QString &outString)
     QList <int> uninformativeNonCoding;
 
     //Test for informative
-    x.testForUninformative(speciesList, uninformativeCoding, uninformativeNonCoding);
+    x.checkForUninformative(speciesList, uninformativeCoding, uninformativeNonCoding);
     x.stripUninformativeCharacters(speciesList, uninformativeCoding, uninformativeNonCoding);
     out << "\nThere should be 17 informative characters.\n";
     if (speciesList[0]->genome.length() != 17) testFlag = false;
@@ -1183,7 +1183,7 @@ bool testinternal::testTen(QString &outString)
 
         uninformativeCoding.clear();
         uninformativeNonCoding.clear();
-        x.testForUninformative(speciesList2, uninformativeCoding, uninformativeNonCoding);
+        x.checkForUninformative(speciesList2, uninformativeCoding, uninformativeNonCoding);
 
         out << "Uninformative characters created: " << uninformativeCount << " Uninformative characters counted " << (uninformativeCoding.length() + uninformativeNonCoding.length()) << "\n";
         if (uninformativeCount != (uninformativeCoding.length() + uninformativeNonCoding.length()))
@@ -1240,8 +1240,8 @@ bool testinternal::testTen(QString &outString)
 
     uninformativeCoding.clear();
     uninformativeNonCoding.clear();
-    y.testForUninformative(speciesList3, uninformativeCoding, uninformativeNonCoding);
-    bool continueToStrip = y.testForCharacterNumber(uninformativeCoding, uninformativeNonCoding);
+    y.checkForUninformative(speciesList3, uninformativeCoding, uninformativeNonCoding);
+    bool continueToStrip = y.checkForCharacterNumber(uninformativeCoding, uninformativeNonCoding);
 
     if (continueToStrip)
     {
@@ -1269,8 +1269,8 @@ bool testinternal::testTen(QString &outString)
 
     uninformativeCoding.clear();
     uninformativeNonCoding.clear();
-    y.testForUninformative(speciesList3, uninformativeCoding, uninformativeNonCoding);
-    continueToStrip = y.testForCharacterNumber(uninformativeCoding, uninformativeNonCoding);
+    y.checkForUninformative(speciesList3, uninformativeCoding, uninformativeNonCoding);
+    continueToStrip = y.checkForCharacterNumber(uninformativeCoding, uninformativeNonCoding);
 
     if (continueToStrip)
     {
@@ -1298,8 +1298,8 @@ bool testinternal::testTen(QString &outString)
 
     uninformativeCoding.clear();
     uninformativeNonCoding.clear();
-    y.testForUninformative(speciesList3, uninformativeCoding, uninformativeNonCoding);
-    continueToStrip = y.testForCharacterNumber(uninformativeCoding, uninformativeNonCoding);
+    y.checkForUninformative(speciesList3, uninformativeCoding, uninformativeNonCoding);
+    continueToStrip = y.checkForCharacterNumber(uninformativeCoding, uninformativeNonCoding);
 
     if (continueToStrip)
     {
@@ -1328,8 +1328,8 @@ bool testinternal::testTen(QString &outString)
 
     uninformativeCoding.clear();
     uninformativeNonCoding.clear();
-    y.testForUninformative(speciesList3, uninformativeCoding, uninformativeNonCoding);
-    continueToStrip = y.testForCharacterNumber(uninformativeCoding, uninformativeNonCoding);
+    y.checkForUninformative(speciesList3, uninformativeCoding, uninformativeNonCoding);
+    continueToStrip = y.checkForCharacterNumber(uninformativeCoding, uninformativeNonCoding);
     if (continueToStrip) y.stripUninformativeCharacters(speciesList3, uninformativeCoding, uninformativeNonCoding);
 
     if (!continueToStrip || speciesList3[0]->genome.size() != 50)

--- a/testinternal.cpp
+++ b/testinternal.cpp
@@ -1619,7 +1619,7 @@ bool testinternal::testFourteen(QString &outString)
 
     //Next we need to do tests when we have more than one parental genome
     org.parentGenomes.append(QList <bool>());
-    for (auto &p : org.parentGenomes[1]) p = false;
+    for (int i = 0; i < 50; i++)org.parentGenomes[1].append(false);
 
     //At the moment, parent genome has four trues - everything should still be below species differemce no new species
     for (int i = 0; i < 3; i++)

--- a/testinternal.cpp
+++ b/testinternal.cpp
@@ -733,71 +733,71 @@ bool testinternal::testSeven(QString &outString)
     QTextStream out(&outString);
 
     out << "Testing new species - new species created at iteration 66 with a genome of all 1's.\n\n";
+    /*
+        simulationVariables simSettings;
+        simSettings.genomeSize = 50;
+        simSettings.fitnessSize = 50;
+        simSettings.speciesSelectSize = 50;
+        simSettings.test = 7;
 
-    simulationVariables simSettings;
-    simSettings.genomeSize = 50;
-    simSettings.fitnessSize = 50;
-    simSettings.speciesSelectSize = 50;
-    simSettings.test = 7;
+        simulation x(0, &simSettings, &error, theMainWindow);
 
-    simulation x(0, &simSettings, &error, theMainWindow);
+        if (error)
+        {
+            out << "Error initialising test simulation";
+            return false;
+        }
+        //This should update the counters on new species
+        x.iterations = 66;
+        x.speciesCount = 14;
 
-    if (error)
-    {
-        out << "Error initialising test simulation";
-        return false;
-    }
-    //This should update the counters on new species
-    x.iterations = 66;
-    x.speciesCount = 14;
+        //This will have initialised values - i.e. zero for everything except the genome, which will be 50% 1's
+        Organism newSpecies(50, false);
+        newSpecies.initialise(50);
+        newSpecies.speciesID = 10;
+        for (auto &i : newSpecies.genome) i = true;
 
-    //This will have initialised values - i.e. zero for everything except the genome, which will be 50% 1's
-    Organism newSpecies(50, false);
-    newSpecies.initialise(50);
-    newSpecies.speciesID = 10;
-    for (auto &i : newSpecies.genome) i = true;
+        Organism parentSpecies(50, false);
+        for (auto &i : parentSpecies.genome)i = true;
+        for (auto &i : parentSpecies.parentGenome)i = true;
+        parentSpecies.speciesID = 10;
+        parentSpecies.parentSpeciesID = 9;
+        parentSpecies.born = 15;
+        parentSpecies.extinct = 20;
+        parentSpecies.cladogenesis = 25;
+        parentSpecies.fitness = 5;
+        x.playingFields[0]->playingField[8]->speciesID = 10;
 
-    Organism parentSpecies(50, false);
-    for (auto &i : parentSpecies.genome)i = true;
-    for (auto &i : parentSpecies.parentGenome)i = true;
-    parentSpecies.speciesID = 10;
-    parentSpecies.parentSpeciesID = 9;
-    parentSpecies.born = 15;
-    parentSpecies.extinct = 20;
-    parentSpecies.cladogenesis = 25;
-    parentSpecies.fitness = 5;
-    x.playingFields[0]->playingField[8]->speciesID = 10;
+        x.newSpecies(newSpecies, parentSpecies, x.playingFields[0]);
 
-    x.newSpecies(newSpecies, parentSpecies, x.playingFields[0]);
+        //Ok, so first, newspecies should be born iteration 66
+        if (newSpecies.born != 66)testFlag = false;
+        out << "New species born at iteration " << newSpecies.born << " (should be 66).\n";
+        if (x.speciesCount != 15)testFlag = false;
+        out << "Species number " << x.speciesCount << " (should be 15).\n";
+        if (newSpecies.speciesID != 15)testFlag = false;
+        out << "New species is " << newSpecies.speciesID << " (should be 15).\n";
+        if (newSpecies.cladogenesis != 66)testFlag = false;
+        out << "New species cladogenesis at iteration " << newSpecies.cladogenesis << " (should be 66).\n";
+        if (parentSpecies.cladogenesis != 66)testFlag = false;
+        out << "Parent cladogenesis at iteration " << parentSpecies.cladogenesis << " (should be 66).\n";
+        if (newSpecies.parentSpeciesID != 10)testFlag = false;
+        out << "New species parent species ID " << newSpecies.parentSpeciesID << " (should be 10).\n";
+        for (auto i : std::as_const(newSpecies.parentGenome)) if (i != 1)testFlag = false;
+        out << "New species parent genome: ";
+        for (auto i : std::as_const(newSpecies.parentGenome)) i ? out << "1" : out << "0";
+        out << " (should be all 1s).\n";
+        for (auto i : std::as_const(newSpecies.genome)) if (i != 1)testFlag = false;
+        out << "New species genome: ";
+        for (auto i : std::as_const(newSpecies.genome)) i ? out << "1" : out << "0";
+        out << " (should be all 1s).\n";
+        for (auto i : std::as_const(x.playingFields[0]->playingField[8]->parentGenome)) if (i != 1)testFlag = false;
+        out << "Species 10 parent genome in playing field is now: ";
+        for (auto i :  std::as_const(x.playingFields[0]->playingField[8]->parentGenome)) i ? out << "1" : out << "0";
+        out << " (should be all 1s).\n";
 
-    //Ok, so first, newspecies should be born iteration 66
-    if (newSpecies.born != 66)testFlag = false;
-    out << "New species born at iteration " << newSpecies.born << " (should be 66).\n";
-    if (x.speciesCount != 15)testFlag = false;
-    out << "Species number " << x.speciesCount << " (should be 15).\n";
-    if (newSpecies.speciesID != 15)testFlag = false;
-    out << "New species is " << newSpecies.speciesID << " (should be 15).\n";
-    if (newSpecies.cladogenesis != 66)testFlag = false;
-    out << "New species cladogenesis at iteration " << newSpecies.cladogenesis << " (should be 66).\n";
-    if (parentSpecies.cladogenesis != 66)testFlag = false;
-    out << "Parent cladogenesis at iteration " << parentSpecies.cladogenesis << " (should be 66).\n";
-    if (newSpecies.parentSpeciesID != 10)testFlag = false;
-    out << "New species parent species ID " << newSpecies.parentSpeciesID << " (should be 10).\n";
-    for (auto i : std::as_const(newSpecies.parentGenome)) if (i != 1)testFlag = false;
-    out << "New species parent genome: ";
-    for (auto i : std::as_const(newSpecies.parentGenome)) i ? out << "1" : out << "0";
-    out << " (should be all 1s).\n";
-    for (auto i : std::as_const(newSpecies.genome)) if (i != 1)testFlag = false;
-    out << "New species genome: ";
-    for (auto i : std::as_const(newSpecies.genome)) i ? out << "1" : out << "0";
-    out << " (should be all 1s).\n";
-    for (auto i : std::as_const(x.playingFields[0]->playingField[8]->parentGenome)) if (i != 1)testFlag = false;
-    out << "Species 10 parent genome in playing field is now: ";
-    for (auto i :  std::as_const(x.playingFields[0]->playingField[8]->parentGenome)) i ? out << "1" : out << "0";
-    out << " (should be all 1s).\n";
-
-    if (testFlag) out << "\nNew species tests passed.\n";
-
+        if (testFlag) out << "\nNew species tests passed.\n";
+    */
     return testFlag;
 }
 
@@ -1564,48 +1564,49 @@ bool testinternal::testFourteen(QString &outString)
     QTextStream out(&outString);
 
     out << "Testing difference to parent.\n\n";
+    /*
+        //Initialised to false
+        Organism org(50, false);
+        for (auto &p : org.parentGenome) p = true;
 
-    //Initialised to false
-    Organism org(50, false);
-    for (auto &p : org.parentGenome) p = true;
+        simulationVariables simSettings;
+        simSettings.test = 14;
+        simulation x(0, &simSettings, &error, theMainWindow);
+        if (error) return false;
 
-    simulationVariables simSettings;
-    simSettings.test = 14;
-    simulation x(0, &simSettings, &error, theMainWindow);
-    if (error) return false;
+        int diff = x.checkForSpeciation(&org, 50);
 
-    int diff = x.checkForSpeciation(&org, 50);
+        out << "Set genome to false, parent to true, select size 50. Should be 50, returns " << diff << ".\n";
+        if (diff != 50)
+        {
+            testFlag = false;
+        }
 
-    out << "Set genome to false, parent to true, select size 50. Should be 50, returns " << diff << ".\n";
-    if (diff != 50)
-    {
-        testFlag = false;
-    }
+        diff = x.checkForSpeciation(&org, 25);
 
-    diff = x.checkForSpeciation(&org, 25);
+        out << "Set genome to false, parent to true, select size 25. Should be 25, returns " << diff << ".\n";
+        if (diff != 25)
+        {
+            testFlag = false;
+        }
 
-    out << "Set genome to false, parent to true, select size 25. Should be 25, returns " << diff << ".\n";
-    if (diff != 25)
-    {
-        testFlag = false;
-    }
+        for (auto &p : org.parentGenome) p = false;
+        diff = x.checkForSpeciation(&org, 50);
 
-    for (auto &p : org.parentGenome) p = false;
-    diff = x.checkForSpeciation(&org, 50);
+        out << "Set genome to false, parent to false, select size 50. Should be 0, returns " << diff << ".\n";
+        if (diff != 0)
+        {
+            testFlag = false;
+        }
 
-    out << "Set genome to false, parent to false, select size 50. Should be 0, returns " << diff << ".\n";
-    if (diff != 0)
-    {
-        testFlag = false;
-    }
+        diff = x.checkForSpeciation(&org, 25);
 
-    diff = x.checkForSpeciation(&org, 25);
-
-    out << "Set genome to false, parent to false, select size 25. Should be 0, returns " << diff << ".\n";
-    if (diff != 0)
-    {
-        testFlag = false;
-    }
+        out << "Set genome to false, parent to false, select size 25. Should be 0, returns " << diff << ".\n";
+        if (diff != 0)
+        {
+            testFlag = false;
+        }
+    */
 
     return testFlag;
 }

--- a/testinternal.cpp
+++ b/testinternal.cpp
@@ -1631,57 +1631,65 @@ bool testinternal::testFourteen(QString &outString)
             out << "Fail at all species modes test C" << i << "\n";
         }
     }
-    if (testFlag) out << "\n All species mode tests with single ancestor passed \n\n";
 
+    //Turn one bit true to take us above species difference
+    org.parentGenomes[0][4] = true;
 
-    /*
-        newSpecies = x.checkForSpeciation(&org, 50, 5, SPECIES_MODE_ORIGIN);
-        if (!newSpecies)
-        {
-            testFlag = false;
-            out << "Fail at all species modes test 1\n";
-        }
+    // This should now be a new species
+    newSpecies = x.checkForSpeciation(&org, 50, 5, SPECIES_MODE_ORIGIN);
+    if (!newSpecies)
+    {
+        testFlag = false;
+        out << "Fail at all species modes test D1\n";
+    }
 
-        newSpecies = x.checkForSpeciation(&org, 50, 5, SPECIES_MODE_LAST_SPECIATION);
-        if (!newSpecies)
-        {
-            testFlag = false;
-            out << "Fail at all species modes test 2\n";
-        }
+    //Should not be new species if we are comparing to last
+    newSpecies = x.checkForSpeciation(&org, 50, 5, SPECIES_MODE_LAST_SPECIATION);
+    if (newSpecies)
+    {
+        testFlag = false;
+        out << "Fail at all species modes test D2\n";
+    }
 
-        newSpecies = x.checkForSpeciation(&org, 50, 5, SPECIES_MODE_ALL);
-        if (!newSpecies)
-        {
-            testFlag = false;
-            out << "Fail at all species modes test 3\n";
-        }
+    //Should be new species as this includes first
+    newSpecies = x.checkForSpeciation(&org, 50, 5, SPECIES_MODE_ALL);
+    if (!newSpecies)
+    {
+        testFlag = false;
+        out << "Fail at all species modes test D3\n";
+    }
 
-        //Turn one bit false to take us below species difference
-        org.parentGenomes[0][4] = false;
+    //Turn one bit false to take us below species difference
+    org.parentGenomes[0][4] = false;
+    //Turn five to true in last speciation
+    for (int i = 0; i < 5; i++)
+    {
+        org.parentGenomes[1][i] = true;
+    }
 
-        newSpecies = x.checkForSpeciation(&org, 50, 5, SPECIES_MODE_ORIGIN);
-        if (newSpecies)
-        {
-            testFlag = false;
-            out << "Fail at all species modes test 4\n";
-        }
+    newSpecies = x.checkForSpeciation(&org, 50, 5, SPECIES_MODE_ORIGIN);
+    if (newSpecies)
+    {
+        testFlag = false;
+        out << "Fail at all species modes test E1\n";
+    }
 
-        newSpecies = x.checkForSpeciation(&org, 50, 5, SPECIES_MODE_LAST_SPECIATION);
-        if (newSpecies)
-        {
-            testFlag = false;
-            out << "Fail at all species modes test 5\n";
-        }
+    newSpecies = x.checkForSpeciation(&org, 50, 5, SPECIES_MODE_LAST_SPECIATION);
+    if (!newSpecies)
+    {
+        testFlag = false;
+        out << "Fail at all species modes test E2\n";
+    }
 
-        newSpecies = x.checkForSpeciation(&org, 50, 5, SPECIES_MODE_ALL);
-        if (newSpecies)
-        {
-            testFlag = false;
-            out << "Fail at all species modes test 6\n";
-        }
-        if (testFlag) out << "\n All species mode tests with single ancestor passed \n\n";
+    newSpecies = x.checkForSpeciation(&org, 50, 5, SPECIES_MODE_ALL);
+    if (!newSpecies)
+    {
+        testFlag = false;
+        out << "Fail at all species modes test E3\n";
+    }
 
-    */
+    if (testFlag) out << "\n All species mode tests with multiple ancestors passed \n\n";
+
     return testFlag;
 }
 

--- a/testinternal.cpp
+++ b/testinternal.cpp
@@ -1580,7 +1580,7 @@ bool testinternal::testFourteen(QString &outString)
         org.parentGenomes[0][i] = true;
     }
 
-    out << "Testing all species modes with a single ancestor (i.e. the parent) genome.\n";
+    out << "Testing all species modes with a single ancestor (i.e. the parent) genome.\n\n";
 
     bool newSpecies = false;
     //Cycle through species modes
@@ -1608,16 +1608,9 @@ bool testinternal::testFourteen(QString &outString)
             out << "Fail at all species modes test B" << i << "\n";
         }
     }
-    if (testFlag) out << "\n All species mode tests with single ancestor passed \n\n";
+    if (testFlag) out << "All species mode tests with single ancestor passed.\n\n";
 
-    //Speciation modes are defined as follows
-    //SPECIES_MODE_ORIGIN 0
-    //SPECIES_MODE_LAST_SPECIATION 1
-    //SPECIES_MODE_ALL 2
-    //SPECIES_MODE_MAYR 3 - not currently implemented
-    //checkForSpeciation(const Organism *organismOne, int runSelectSize, int runSpeciesDifference, int speciationMode)
-
-    //Next we need to do tests when we have more than one parental genome
+    //Next we need to do tests when we have more than one ancestral genome
     org.parentGenomes.append(QList <bool>());
     for (int i = 0; i < 50; i++)org.parentGenomes[1].append(false);
 
@@ -1661,7 +1654,7 @@ bool testinternal::testFourteen(QString &outString)
 
     //Turn one bit false to take us below species difference
     org.parentGenomes[0][4] = false;
-    //Turn five to true in last speciation
+    //Turn five to true in last (now second) speciation
     for (int i = 0; i < 5; i++)
     {
         org.parentGenomes[1][i] = true;
@@ -1688,7 +1681,188 @@ bool testinternal::testFourteen(QString &outString)
         out << "Fail at all species modes test E3\n";
     }
 
-    if (testFlag) out << "\n All species mode tests with multiple ancestors passed \n\n";
+    if (testFlag) out << "All species mode tests with two ancestors passed.\n\n";
+
+    //Finally, we need to do tests when we have more than two ancestral genome
+    org.parentGenomes.append(QList <bool>());
+    for (int i = 0; i < 50; i++)org.parentGenomes[2].append(false);
+    //Set all others to fales too
+    for (auto &p : org.parentGenomes[0]) p = false;
+    for (auto &p : org.parentGenomes[1]) p = false;
+
+    //No new species expected
+    newSpecies = x.checkForSpeciation(&org, 50, 5, SPECIES_MODE_ORIGIN);
+    if (newSpecies)
+    {
+        testFlag = false;
+        out << "Fail at all species modes test F1\n";
+    }
+
+    newSpecies = x.checkForSpeciation(&org, 50, 5, SPECIES_MODE_LAST_SPECIATION);
+    if (newSpecies)
+    {
+        testFlag = false;
+        out << "Fail at all species modes test F2\n";
+    }
+
+    newSpecies = x.checkForSpeciation(&org, 50, 5, SPECIES_MODE_ALL);
+    if (newSpecies)
+    {
+        testFlag = false;
+        out << "Fail at all species modes test F3\n";
+    }
+
+    //Test with original five away
+    for (int i = 0; i < 5; i++)
+    {
+        org.parentGenomes[0][i] = true;
+    }
+
+    //Should be new species
+    newSpecies = x.checkForSpeciation(&org, 50, 5, SPECIES_MODE_ORIGIN);
+    if (!newSpecies)
+    {
+        testFlag = false;
+        out << "Fail at all species modes test F1\n";
+    }
+
+    //Should not
+    newSpecies = x.checkForSpeciation(&org, 50, 5, SPECIES_MODE_LAST_SPECIATION);
+    if (newSpecies)
+    {
+        testFlag = false;
+        out << "Fail at all species modes test F2\n";
+    }
+
+    //Should be
+    newSpecies = x.checkForSpeciation(&org, 50, 5, SPECIES_MODE_ALL);
+    if (!newSpecies)
+    {
+        testFlag = false;
+        out << "Fail at all species modes test F3\n";
+    }
+
+    //Test with middle five away, reset original
+    for (auto &p : org.parentGenomes[0]) p = false;
+    for (int i = 0; i < 5; i++)
+    {
+        org.parentGenomes[1][i] = true;
+    }
+
+    newSpecies = x.checkForSpeciation(&org, 50, 5, SPECIES_MODE_ORIGIN);
+    if (newSpecies)
+    {
+        testFlag = false;
+        out << "Fail at all species modes test G1\n";
+    }
+
+    newSpecies = x.checkForSpeciation(&org, 50, 5, SPECIES_MODE_LAST_SPECIATION);
+    if (newSpecies)
+    {
+        testFlag = false;
+        out << "Fail at all species modes test G2\n";
+    }
+
+    //Should be new species
+    newSpecies = x.checkForSpeciation(&org, 50, 5, SPECIES_MODE_ALL);
+    if (!newSpecies)
+    {
+        testFlag = false;
+        out << "Fail at all species modes test G3\n";
+    }
+
+    //Test with last five on, reset middle
+    for (auto &p : org.parentGenomes[1]) p = false;
+    for (int i = 0; i < 5; i++)
+    {
+        org.parentGenomes[2][i] = true;
+    }
+
+    //Shouldn't be new species
+    newSpecies = x.checkForSpeciation(&org, 50, 5, SPECIES_MODE_ORIGIN);
+    if (newSpecies)
+    {
+        testFlag = false;
+        out << "Fail at all species modes test H1\n";
+    }
+
+    //Should
+    newSpecies = x.checkForSpeciation(&org, 50, 5, SPECIES_MODE_LAST_SPECIATION);
+    if (!newSpecies)
+    {
+        testFlag = false;
+        out << "Fail at all species modes test H2\n";
+    }
+
+    newSpecies = x.checkForSpeciation(&org, 50, 5, SPECIES_MODE_ALL);
+    if (!newSpecies)
+    {
+        testFlag = false;
+        out << "Fail at all species modes test H3\n";
+    }
+
+    //Test with last and middle five
+    for (int i = 0; i < 5; i++)
+    {
+        org.parentGenomes[1][i] = true;
+    }
+
+    //Shouldn't be new species
+    newSpecies = x.checkForSpeciation(&org, 50, 5, SPECIES_MODE_ORIGIN);
+    if (newSpecies)
+    {
+        testFlag = false;
+        out << "Fail at all species modes test I1\n";
+    }
+
+    //Should
+    newSpecies = x.checkForSpeciation(&org, 50, 5, SPECIES_MODE_LAST_SPECIATION);
+    if (!newSpecies)
+    {
+        testFlag = false;
+        out << "Fail at all species modes test I2\n";
+    }
+
+    //Should
+    newSpecies = x.checkForSpeciation(&org, 50, 5, SPECIES_MODE_ALL);
+    if (!newSpecies)
+    {
+        testFlag = false;
+        out << "Fail at all species modes test I3\n";
+    }
+
+    //Test with first and middle, not last
+    for (auto &p : org.parentGenomes[2]) p = false;
+    for (int i = 0; i < 5; i++)
+    {
+        org.parentGenomes[0][i] = true;
+    }
+
+    //Should be new species
+    newSpecies = x.checkForSpeciation(&org, 50, 5, SPECIES_MODE_ORIGIN);
+    if (!newSpecies)
+    {
+        testFlag = false;
+        out << "Fail at all species modes test J1\n";
+    }
+
+    //Shouldn't
+    newSpecies = x.checkForSpeciation(&org, 50, 5, SPECIES_MODE_LAST_SPECIATION);
+    if (newSpecies)
+    {
+        testFlag = false;
+        out << "Fail at all species modes test J2\n";
+    }
+
+    //Should
+    newSpecies = x.checkForSpeciation(&org, 50, 5, SPECIES_MODE_ALL);
+    if (!newSpecies)
+    {
+        testFlag = false;
+        out << "Fail at all species modes test J3\n";
+    }
+
+    if (testFlag) out << "All species mode tests with more than two ancestors passed.\n\n";
 
     return testFlag;
 }

--- a/testinternal.cpp
+++ b/testinternal.cpp
@@ -791,12 +791,14 @@ bool testinternal::testSeven(QString &outString)
     out << "New species genome: ";
     for (auto i : std::as_const(newSpecies.genome)) i ? out << "1" : out << "0";
     out << " (should be all 1s).\n";
-    for (auto i : std::as_const(x.playingFields[0]->playingField[8]->parentGenomes[0])) if (i != 1)testFlag = false;
+    for (auto i : std::as_const(x.playingFields[0]->playingField[8]->parentGenomes[0])) if (i != 0)testFlag = false;
     out << "Species 10 parent genome in playing field is now: ";
     for (auto i :  std::as_const(x.playingFields[0]->playingField[8]->parentGenomes[0])) i ? out << "1" : out << "0";
-    out << " (should be all 1s).\n";
-    out << "Now look at appended genome.";
+    out << " (should be all 0s).\n";
+    for (auto i : std::as_const(x.playingFields[0]->playingField[8]->parentGenomes[1])) if (i != 1)testFlag = false;
+    out << "Species 10 last speciation genome in playing field is now:";
     for (auto i :  std::as_const(x.playingFields[0]->playingField[8]->parentGenomes[1])) i ? out << "1" : out << "0";
+    out << " (should be all 1s).\n";
 
     if (testFlag) out << "\nNew species tests passed.\n";
 


### PR DESCRIPTION
Provide three different speciation modes within trevosim (see discussion in issue #59 ), namely:

- Through comparison to species origin
- Through comparison to last speciation
- By comparing to both the species origin and all other speciations

This includes updates to the simulation to facilitate this - primarily in the function used to ID a new species, which now returns a bool, and also in the function which new species are implemented. Tests seven and fourteen have been updated to reflect these changes.  